### PR TITLE
remove typing variables in analysis.py (l23-24)

### DIFF
--- a/src/pyfiber/analysis.py
+++ b/src/pyfiber/analysis.py
@@ -20,8 +20,8 @@ st.use("ggplot")
 
 __all__ = ["Session", "MultiSession", "Analysis", "MultiAnalysis"]
 
-type Intervals = List[Tuple[float, float]]
-type Events = np.ndarray
+Intervals = List[Tuple[float, float]]
+Events = np.ndarray
 
 
 class Session(PyFiber):


### PR DESCRIPTION
Typing variable is only available for python3.12 or upper. To avoid version limitations, we replace 

```
type Intervals = List[Tuple[float, float]]
type Events = np.ndarray
```

by 

```
Intervals = List[Tuple[float, float]]
Events = np.ndarray
```